### PR TITLE
Adding codeowners, that way we don't forget to add someone to a PR

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @theknarf @trulsaa @mikkelcodes


### PR DESCRIPTION
This uses Github's [Codeowner](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) feature so that we all automatically get added as reviewers to all PR's.