### PR TITLE
Seems like double build is no longer needed

### DIFF
--- a/website.Dockerfile
+++ b/website.Dockerfile
@@ -13,9 +13,7 @@ COPY packages/website /app/packages/website/
 RUN yarn
 
 RUN yarn workspace website run disable-telemetry
-# How the fuck did we fuck this up
-# Now it only successfully builds if we build it twice in a row?
-RUN yarn workspace website run build; yarn workspace website run build
+RUN yarn workspace website run build
 
 # Stage 2 - Webserver using Ngnix
 FROM nginx:1.18-alpine


### PR DESCRIPTION
Unsure why this started working again.
One tips I got was to run docker build with --no-cache if something
strange like that happens again