### PR TITLE
Splitting deployment pipelines, adding scheduled deployment.

### DIFF
--- a/.AzureDevOps/pipelines/azure-pipelines-dev.yml
+++ b/.AzureDevOps/pipelines/azure-pipelines-dev.yml
@@ -1,0 +1,40 @@
+trigger:
+  - master
+
+pr: none
+
+pool:
+  vmImage: ubuntu-latest
+
+variables:
+  subscriptionId: '32547ca3-abba-45c8-b76e-46a590958b5e'
+  serviceName: alvnodev
+  serviceConnection: AlvNo-Dev
+  envFileName: '.env.production'
+
+stages:
+  - stage: build
+    displayName: Build and test
+    jobs:
+      - job: githash
+        displayName: Build
+        steps:
+          - template: ../../packages/infrastructure/build-steps.yaml
+
+  - stage: test
+    displayName: Deploy to Test
+    jobs:
+      - deployment: Test
+        variables:
+          subscriptionId: '32547ca3-abba-45c8-b76e-46a590958b5e'
+          serviceName: alvnodev
+          serviceConnection: AlvNo-Dev
+          hostname: "dev.alv.no"
+          envFileName: '.env.production'
+        displayName: Test
+        environment: Test
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - template: ../../packages/infrastructure/deploy-steps.yaml

--- a/.AzureDevOps/pipelines/azure-pipelines.yml
+++ b/.AzureDevOps/pipelines/azure-pipelines.yml
@@ -1,7 +1,20 @@
 trigger:
-  - master
+  - prod
 
 pr: none
+
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#cron-syntax
+#schedules:
+#- cron: "30 10 * * 2"
+#  displayName: Thusdays at 1030
+#  branches:
+#    include:
+#    - prod
+#- cron: "0 16 * * 4"
+#  displayName: Thursday at 1600
+#  branches:
+#    include:
+#    - prod
 
 pool:
   vmImage: ubuntu-latest
@@ -10,7 +23,7 @@ variables:
   subscriptionId: '32547ca3-abba-45c8-b76e-46a590958b5e'
   serviceName: alvnodev
   serviceConnection: AlvNo-Dev
-  envFileName: '.env.development'
+  envFileName: '.env.production'
 
 stages:
   - stage: build
@@ -20,24 +33,6 @@ stages:
         displayName: Build
         steps:
           - template: ../../packages/infrastructure/build-steps.yaml
-
-  - stage: test
-    displayName: Deploy to Test
-    jobs:
-      - deployment: Test
-        variables:
-          subscriptionId: '32547ca3-abba-45c8-b76e-46a590958b5e'
-          serviceName: alvnodev
-          serviceConnection: AlvNo-Dev
-          hostname: "dev.alv.no"
-          envFileName: '.env.production'
-        displayName: Test
-        environment: Test
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - template: ../../packages/infrastructure/deploy-steps.yaml
 
   - stage: prod
     displayName: Deploy to Production


### PR DESCRIPTION
Todo after merging this PR:

- Create a new build pipeline in Azure Devops based on the new ` .AzureDevOps/pipelines/azure-pipelines-dev.yml` file.
- Add the `.env.production` file to that pipeline
- Create a PR from master to prod
- Test both the new dev pipeline and the prod pipeline
- See in the GUI at Azure Devops if theres any way to check that scheduling is setup correctly