### PR TITLE
Added google-tag-manager to ALV-B

### DIFF
--- a/packages/website-alvb/gatsby-config.js
+++ b/packages/website-alvb/gatsby-config.js
@@ -17,6 +17,14 @@ module.exports = {
         head: true,
       },
     },
+    {
+      resolve: 'gatsby-plugin-google-tagmanager',
+      options: {
+        id: 'GTM-KJX5NRJ',
+        includeInDevelopment: false,
+        enableWebVitalsTracking: true,
+      },
+    },
     'gatsby-plugin-image',
     'gatsby-transformer-sharp',
     'gatsby-plugin-sharp',

--- a/packages/website-alvb/package.json
+++ b/packages/website-alvb/package.json
@@ -18,6 +18,7 @@
     "classnames": "^2.2.6",
     "gatsby-background-image": "^1.5.3",
     "gatsby-plugin-google-analytics": "^4.1.0",
+    "gatsby-plugin-google-tagmanager": "^4.6.0",
     "gatsby-plugin-manifest": "^4.1.3",
     "gatsby-plugin-webpack-bundle-analyzer": "^1.0.5",
     "gbimage-bridge": "^0.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -35493,7 +35493,6 @@ typescript@^4.0.5:
     gatsby-plugin-facebook-pixel: ^1.0.8
     gatsby-plugin-google-analytics: ^4.1.0
     gatsby-plugin-google-fonts: ^1.0.1
-    gatsby-plugin-google-tagmanager: ^4.6.0
     gatsby-plugin-image: ^2.1.2
     gatsby-plugin-manifest: ^4.1.3
     gatsby-plugin-postcss: ^5.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -18267,6 +18267,20 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"gatsby-plugin-google-tagmanager@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "gatsby-plugin-google-tagmanager@npm:4.6.0"
+  dependencies:
+    "@babel/runtime": ^7.15.4
+    web-vitals: ^1.1.2
+  peerDependencies:
+    gatsby: ^4.0.0-next
+    react: ^16.9.0 || ^17.0.0
+    react-dom: ^16.9.0 || ^17.0.0
+  checksum: 40b51c2819f735ed192cb7d40af148e1733bb9fd40309f363195d854a9f8a8a6a7ceb074d2421384be62dca70dbaa603e311012fa456ad09a37f3ad72e98238e
+  languageName: node
+  linkType: hard
+
 "gatsby-plugin-image@npm:^2.1.2":
   version: 2.1.2
   resolution: "gatsby-plugin-image@npm:2.1.2"
@@ -35418,6 +35432,7 @@ typescript@^4.0.5:
     gatsby-image: ^3.11.0
     gatsby-plugin-google-analytics: ^4.1.0
     gatsby-plugin-google-fonts: ^1.0.1
+    gatsby-plugin-google-tagmanager: ^4.6.0
     gatsby-plugin-image: ^2.1.2
     gatsby-plugin-manifest: ^4.1.3
     gatsby-plugin-postcss: ^5.1.0
@@ -35478,6 +35493,7 @@ typescript@^4.0.5:
     gatsby-plugin-facebook-pixel: ^1.0.8
     gatsby-plugin-google-analytics: ^4.1.0
     gatsby-plugin-google-fonts: ^1.0.1
+    gatsby-plugin-google-tagmanager: ^4.6.0
     gatsby-plugin-image: ^2.1.2
     gatsby-plugin-manifest: ^4.1.3
     gatsby-plugin-postcss: ^5.1.0


### PR DESCRIPTION
Added gatsby-plugin-google-tagmanager
- Verified that the script-tag is added to the public-content after the build