### PR TITLE
Permalinks no longer needs a trailing slash 🐛

### DIFF
--- a/website.nginx.conf
+++ b/website.nginx.conf
@@ -3,6 +3,8 @@ server {
 
   index index.html;
 
+  absolute_redirect off;
+
   error_page 404 /404.html;
 
   rewrite ^([^.\?]*[^/])$ $1/ permanent;


### PR DESCRIPTION
closes #658
Permalinks without trailing slash would not give any good results.
By adding one line to the nginx-config we see that our nginx-Server
responds with a proper response. As another benefit we see that the
docker image behaves much nicer locally than what it did earlier.
Testing should be exactly the same locally as test/prod