### PR TITLE
682 wrong social media links

### DIFF
--- a/packages/shared-components/src/components/socialShare/index.js
+++ b/packages/shared-components/src/components/socialShare/index.js
@@ -6,8 +6,14 @@ import {
   LinkedinShareButton,
 } from 'react-share';
 
-export const SocialShare = ({ url, title, tags, subtitle, white }) => {
-  const twitterHandle = 'Alvnoas';
+export const SocialShare = ({
+  url,
+  title,
+  tags,
+  subtitle,
+  white,
+  twitterHandle,
+}) => {
   return (
     <div
       className={`w-full flex justify-end uppercase ${
@@ -24,7 +30,7 @@ export const SocialShare = ({ url, title, tags, subtitle, white }) => {
         <TwitterShareButton
           url={url}
           title={title}
-          via={twitterHandle}
+          via={twitterHandle || ''}
           hashtags={tags}
         >
           <Icon.CircleTwitter white={white} />

--- a/packages/website-alvb/src/components/navigation/index.js
+++ b/packages/website-alvb/src/components/navigation/index.js
@@ -1,7 +1,8 @@
 import { window } from 'browser-monads';
 import Link from 'gatsby-link';
 import React from 'react';
-import { SocialLinks, LargeLink, SubtitleLink, Icon } from 'shared-components';
+import { SocialLinks } from '../socialLinks';
+import { LargeLink, SubtitleLink, Icon } from 'shared-components';
 
 export const Navigation = ({ open, toggleClose, logo, navItems }) => {
   const isEnLocale = window.location.href.includes('/en');

--- a/packages/website-alvb/src/components/socialLinks/index.js
+++ b/packages/website-alvb/src/components/socialLinks/index.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Icon } from 'shared-components';
+
+export const SocialLinks = ({ blue }) => (
+  <div className="eight:flex hidden">
+    <span className="mr-4 ml-5 pl-2px">
+      <a
+        href="https://www.linkedin.com/company/alv-b-as/"
+        target="_blank"
+        rel="noreferrer"
+      >
+        <Icon.Linkedin blue={blue} />
+      </a>
+    </span>
+    <a
+      href="https://www.facebook.com/AlvBNorge"
+      target="_blank"
+      rel="noreferrer"
+    >
+      <Icon.Facebook blue={blue} />
+    </a>
+  </div>
+);


### PR DESCRIPTION
Create local version of social share component for Alv B.

Remove Instagram link.
Direct Facebook and LinkedIn links to correct Alv B sites.
Change social share buttons on blog posts to local version.
Remove user handle and 'via' for Twitter share.