### PR TITLE
Fix #686 - New "twitterHandle" prop on social share component

### DIFF
--- a/packages/website/src/pages/blogg/[slug].js
+++ b/packages/website/src/pages/blogg/[slug].js
@@ -100,6 +100,7 @@ const ArticleTemplate = ({ serverData: { article, articles } }) => {
                 title={socialTitle || title}
                 subtitle={socialSubtitle || description}
                 tags={socialTags}
+                twitterHandle="Alvnoas"
               />
             </div>
             <h1 className="text-blog font-bold mb-8">{title}</h1>


### PR DESCRIPTION
Fix #686 - Adds the new "twitterHandle" prop on the social share component used on blog posts, to make it shared 'via' the Alv Twitter account. A refactoring based on #683. 

