### PR TITLE
Switch  position and adjust service description

### DIFF
--- a/packages/shared-components/src/components/ourServices/index.js
+++ b/packages/shared-components/src/components/ourServices/index.js
@@ -26,7 +26,6 @@ export const OurServices = ({
           gridTemplateColumns: '1fr 1fr',
         }}
       >
-        <div />
         <div className="sm:pl-0 lg:ml-0 pl-5">
           <h2 className="sm:text-5xl text-4xl font-light mb-3 uppercase lg:w-full sm:w-full">
             {/* update alv sanity to use "title" naming convention */}
@@ -47,6 +46,7 @@ export const OurServices = ({
             </div>
           </div>
         </div>
+        <div />
       </div>
       <div
         className="mx-auto lg:grid flex flex-col-reverse gap-x-10"

--- a/packages/website/src/pages/index.js
+++ b/packages/website/src/pages/index.js
@@ -56,6 +56,8 @@ const Index = ({ data, location }) => {
               blocks={landingPage._rawAboutText}
             />
           </div>
+          <OurServices darkFade {...landingPage.section2Services} />
+          <div className="lg:h-40  h-5" />
           <Hire
             darkFade
             title={landingPage.flipSection1Title}
@@ -65,8 +67,6 @@ const Index = ({ data, location }) => {
             image={landingPage.flipSection1Image.asset.gatsbyImageData}
           />
           <div className="bg-navy h-10 lg:h-32" />
-          <OurServices darkFade {...landingPage.section2Services} />
-          <div className="lg:h-40  h-5" />
           <HireAlt
             darkFade
             title={landingPage.flipSection3Title}


### PR DESCRIPTION
Switch position of sections on front page. Fix #688. 

<img width="716" alt="image" src="https://user-images.githubusercontent.com/12566124/167391680-b4c3710a-528a-4fbd-9cb4-562d0dc655f4.png">
