### PR TITLE
Performance increase alv-b

### DIFF
--- a/packages/website-alvb/src/components/blogCarousel/index.js
+++ b/packages/website-alvb/src/components/blogCarousel/index.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { BlogSlider } from 'shared-components';
-import { useBlogQuery } from '../../hookspages/useBlogQuery';
+import { useBlogQueryRecent } from '../../hookspages/useBlogQueryRecent';
 
 export const BlogCarousel = ({ blue, isEnLocale, blueText, maxWidth }) => (
   <BlogSlider
     blue={blue}
-    useBlogQuery={useBlogQuery}
+    useBlogQuery={useBlogQueryRecent}
     isEnLocale={isEnLocale}
     blueText={blueText}
     maxWidth={maxWidth}

--- a/packages/website-alvb/src/hookspages/useBlogQueryRecent.js
+++ b/packages/website-alvb/src/hookspages/useBlogQueryRecent.js
@@ -18,6 +18,7 @@ export const useBlogQueryRecent = () => {
               tags {
                 tag
               }
+              _rawBody
               mainImage {
                 asset {
                   gatsbyImageData(fit: FILLMAX, placeholder: BLURRED)
@@ -32,29 +33,9 @@ export const useBlogQueryRecent = () => {
                 firstname
                 lastname
               }
-              guestAuthor {
-                guestAuthor {
-                  image {
-                    asset {
-                      gatsbyImageData(fit: FILLMAX, placeholder: BLURRED)
-                      url
-                    }
-                  }
-                  firstname
-                  lastname
-                  title
-                  id
-                }
-              }
               publishedAt(formatString: "DD MMM, YYYY")
               rawDate: publishedAt
-              _createdAt
             }
-          }
-        }
-        fallbackImg: file(name: { eq: "featuredFallback" }) {
-          childImageSharp {
-            gatsbyImageData(layout: FULL_WIDTH)
           }
         }
       }

--- a/website-alvb.nginx.conf
+++ b/website-alvb.nginx.conf
@@ -14,7 +14,28 @@ server {
   error_page 404 /404.html;
 
   rewrite ^([^.\?]*[^/])$ $1/ permanent;
+
   try_files $uri $uri/ $uri/index.html =404;
+
+  location ~* \.(?:html)$ {
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+  }
+
+  location /page-data {
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+  }
+
+  location = /sw.js {
+    add_header Cache-Control "public, max-age=0, must-revalidate";
+  }
+
+  location /static {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
+
+  location ~* \.(?:js|css)$ {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+  }
 
   location = /sitemap.xml {
     expires 1d;


### PR DESCRIPTION
- Added a gatsby-reccomended cache policy to static assets only images and javascript is cached. HTML is not
- Reduced the amount of articles in the blog-carousel to reduce DOM-size. Got everything under 900 elements and that removes a lighthouse-warning