### PR TITLE
remove rogue response call

### DIFF
--- a/packages/mail-api/src/index.js
+++ b/packages/mail-api/src/index.js
@@ -63,7 +63,6 @@ app.post("/send", (req, res) => {
         res.sendStatus(500);
       });
   });
-  res.sendStatus(200);
 });
 
 // job application forms


### PR DESCRIPTION
Found a redundant response call. This thing is the cause of a few bad things about the world:
- Sends 200 response regardless of actual response code
- Makes a lot of noise in mail-api logs about headers that have already been set

Be gone!