### PR TITLE
Fix: tracking forms using plausible

### DIFF
--- a/packages/shared-components/src/components/form/index.js
+++ b/packages/shared-components/src/components/form/index.js
@@ -1,7 +1,8 @@
 import { window } from "browser-monads";
 import React, { useEffect, useState } from "react";
+import { trackCustomEvent } from "../../utils/plausible";
 
-const useContactForm = () => {
+const useContactForm = (trackingEventName = "") => {
   const [sent, setSent] = useState(false);
   const [error, setError] = useState(false);
   const mailApiUrl = `${window.location.protocol}//mail-api.${window.location.hostname}/send`;
@@ -13,6 +14,8 @@ const useContactForm = () => {
     const form = e.target;
 
     const data = new FormData(form);
+
+    trackCustomEvent(trackingEventName);
 
     fetch(mailApiUrl, {
       method: "POST",
@@ -29,8 +32,9 @@ const useContactForm = () => {
   return { submitForm, sent, error, mailApiUrl };
 };
 
-export const Call = ({ className = "" }) => {
-  const { submitForm, sent, error, mailApiUrl } = useContactForm();
+export const Call = ({ trackingEventName = "" }) => {
+  const { submitForm, sent, error, mailApiUrl } =
+    useContactForm(trackingEventName);
 
   return (
     <div>
@@ -41,7 +45,7 @@ export const Call = ({ className = "" }) => {
       </div>
       <div className={sent ? "hidden" : ""}>
         <form
-          className={"text-white w-full tracking-wider text-mobile" + className}
+          className={"text-white w-full tracking-wider text-mobile"}
           method="POST"
           action={mailApiUrl}
           onSubmit={submitForm}
@@ -101,9 +105,9 @@ export const Call = ({ className = "" }) => {
 export const Offer = ({
   compact = false,
   sendButtonTransparent = false,
-  className = "",
+  trackingEventName = "",
 }) => {
-  const { submitForm, sent, error } = useContactForm();
+  const { submitForm, sent, error } = useContactForm(trackingEventName);
   const [mailApiUrl, setMailApiUrl] = useState("");
 
   useEffect(() => {
@@ -134,7 +138,7 @@ export const Offer = ({
       </div>
       <div className={sent ? "hidden" : ""}>
         <form
-          className={"text-white w-full tracking-wider text-mobile" + className}
+          className="text-white w-full tracking-wider text-mobile"
           method="POST"
           action={mailApiUrl}
           onSubmit={submitForm}

--- a/packages/shared-components/src/components/richTextTypes/cta/formCta/index.js
+++ b/packages/shared-components/src/components/richTextTypes/cta/formCta/index.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { createFormData, submitWithDelay, useForm } from "../../../../utils";
 import { FormFeedbackWrapper } from "../../../formFeedbackWrapper";
 import * as styles from "./FormCta.module.css";
-import { generatePlausibleClass } from "../../../../utils/plausible";
+import { trackCustomEvent } from "../../../../utils/plausible";
 
 const FormCta = ({ identifier, eyebrow, heading, whiteOnBlue }) => {
   const themeClass = whiteOnBlue ? styles.whiteOnBlue : styles.blueOnWhite;
@@ -33,6 +33,8 @@ const Form = ({ identifier }) => {
 
     setStatus("loading");
 
+    trackCustomEvent("Block Form", { identifier });
+
     const formData = createFormData(inputValues);
 
     const mailApiUrl = `${window.location.protocol}//mail-api.${window.location.hostname}/send`;
@@ -43,16 +45,7 @@ const Form = ({ identifier }) => {
 
   return (
     <FormFeedbackWrapper status={status}>
-      <form
-        className={
-          styles.form +
-          generatePlausibleClass("Block Form", {
-            key: "identifier",
-            value: identifier,
-          })
-        }
-        onSubmit={handleSubmitClick}
-      >
+      <form className={styles.form} onSubmit={handleSubmitClick}>
         <div className="">
           <FormLabel>Navn</FormLabel>
           <input

--- a/packages/shared-components/src/utils/plausible.js
+++ b/packages/shared-components/src/utils/plausible.js
@@ -33,6 +33,10 @@ export const trackCustomEvent = (eventName, eventDetails) => {
     return;
   }
 
+  if (!eventName) {
+    return;
+  }
+
   window.plausible(eventName, {
     props: { ...eventDetails },
   });

--- a/packages/website/src/components/applyForm/index.js
+++ b/packages/website/src/components/applyForm/index.js
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { generatePlausibleClass } from "shared-components";
+import { trackCustomEvent } from "shared-components";
 import { PLAUSIBLE_WORK_FOR_US_FORM } from "../../plausible/plausible-events";
 
 const ApplyForm = ({ jobTitle }) => {
@@ -23,6 +23,8 @@ const ApplyForm = ({ jobTitle }) => {
     const { name, email } = formInputs;
 
     const formData = new FormData();
+
+    trackCustomEvent(PLAUSIBLE_WORK_FOR_US_FORM, { title: jobTitle });
 
     formData.append("subject", "Jobbsøknad - " + jobTitle);
     name && formData.append("name", name);
@@ -64,17 +66,7 @@ const ApplyForm = ({ jobTitle }) => {
   }
 
   return (
-    <form
-      className={
-        "grid" +
-        generatePlausibleClass(PLAUSIBLE_WORK_FOR_US_FORM, {
-          key: "title",
-          value: jobTitle,
-        })
-      }
-      onSubmit={handleSubmit}
-      data-testid="form"
-    >
+    <form className="grid" onSubmit={handleSubmit} data-testid="form">
       <label className="mb-2">Navn *</label>
       <input
         className={

--- a/packages/website/src/pages/kontakt-oss.js
+++ b/packages/website/src/pages/kontakt-oss.js
@@ -94,14 +94,10 @@ const Contact = ({ location }) => {
           </div>
           <div className="flex-1 p-5 sm:p-12 lg:mx-0 lg:pb-15 tracking-wider bg-lightblue">
             {active === "offer" && (
-              <Form.Offer
-                className={generatePlausibleClass(PLAUSIBLE_CONTACT_EMAIL)}
-              />
+              <Form.Offer trackingEventName={PLAUSIBLE_CONTACT_EMAIL} />
             )}
             {active === "call" && (
-              <Form.Call
-                className={generatePlausibleClass(PLAUSIBLE_CONTACT_PHONE)}
-              />
+              <Form.Call trackingEventName={PLAUSIBLE_CONTACT_PHONE} />
             )}
             {active === "visit" && <Form.Visit address={address} org={org} />}
           </div>


### PR DESCRIPTION
This changes how we handle events when using forms
- Plausible wraps event-listeners on forms when applying custom events to it. The code on forms are known to be buggy.
- transitioned to fire events manually instead using `trackCustomEvent`-method