### PR TITLE
No longer showing unpublished job-listings

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@apollo/client": "^3.5.8",
     "@sanity/block-content-to-react": "^2.0.7",
+    "@sanity/client": "^6.1.3",
     "@sanity/image-url": "^0.140.22",
     "autoprefixer": "10.4.13",
     "browser-monads": "^1.0.0",

--- a/packages/website/src/components/layout/index.js
+++ b/packages/website/src/components/layout/index.js
@@ -7,7 +7,6 @@ import "./layout.css";
 const Layout = ({
   layoutData,
   children,
-  path,
   pageDescription,
   pageTitle,
   whiteIcons,
@@ -35,7 +34,6 @@ const Layout = ({
       <SEO description={pageDescription} title={pageTitle} {...metaData} />
       <Header
         white={white}
-        path={path}
         whiteIcons={whiteIcons}
         servicePages={servicePages}
         categoryPages={categoryPages}

--- a/packages/website/src/config.js
+++ b/packages/website/src/config.js
@@ -1,5 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const config = require("gatsby-plugin-config").default;
+
+/**
+ * @typedef {Object} Configuration
+ * @property {string|undefined} SANITY_TOKEN
+ * @property {string|undefined} SANITY_PROJECT_ID
+ * @property {string|undefined} SANITY_DATASET
+ * @property {string|undefined} SANITY_TAG
+ * @property {string|undefined} YT_API
+ * */
+
+/** @type Configuration */
 let configuration;
 switch (config.NODE_ENV) {
   case "development":

--- a/packages/website/src/pages/500.js
+++ b/packages/website/src/pages/500.js
@@ -1,0 +1,27 @@
+import React from "react";
+import Layout from "../components/layout";
+import { useLayoutQuery } from "../hooks/useLayoutQuery";
+
+const NotFoundPage = () => {
+  const layoutData = useLayoutQuery();
+
+  return (
+    <Layout
+      layoutData={layoutData}
+      pageTitle="404 - siden finnes ikke"
+      whiteIcons
+      path={[]}
+    >
+      <div className="min-h-screen bg-navy text-2xl text-white flex items-center justify-center flex-col">
+        <div className="text-center transform -translate-y-20">
+          <h2 className="mb-5">Noe har gått galt</h2>
+          <p>
+            Det kan hende innholdet du forsøkte å hente ikke lenger er publisert
+          </p>
+        </div>
+      </div>
+    </Layout>
+  );
+};
+
+export default NotFoundPage;

--- a/packages/website/src/server-side/imageCreator.js
+++ b/packages/website/src/server-side/imageCreator.js
@@ -13,13 +13,23 @@ function resolveNodeType(asset) {
   return asset.url;
 }
 
-function imageCreator(asset) {
+/** @param {boolean} isGroqResult */
+const getImageMetaData = (asset, isGroqResult) => {
+  if (isGroqResult) {
+    return asset.hotspot;
+  }
+
+  return asset.metadata?.dimensions;
+};
+
+/** @param {boolean} isGroqResult */
+function imageCreator(asset, isGroqResult) {
   const node = resolveNodeType(asset);
   let assets = {};
 
   if (asset.metadata?.dimensions) {
     assets = {
-      ...asset.metadata.dimensions,
+      ...getImageMetaData(asset, isGroqResult),
     };
   }
 
@@ -29,7 +39,12 @@ function imageCreator(asset) {
   });
 }
 
-export function createGatsbyImages(element) {
+/**
+ * Goes through the object recursively and creates `GatsbyImage`-objects
+ * @param {object} element - object from sanity
+ * @param isGroqResult - specifies that the object comes from a GROQ-request
+ *  */
+export function createGatsbyImages(element, isGroqResult = false) {
   if (!element) return;
   Object.keys(element).forEach((subElement) => {
     if (typeof element[subElement] === "object") {
@@ -49,7 +64,7 @@ export function createGatsbyImages(element) {
       element[subElement] === "Image" &&
       element.asset
     ) {
-      element.asset.gatsbyImageData = imageCreator(element.asset);
+      element.asset.gatsbyImageData = imageCreator(element.asset, isGroqResult);
       return;
     }
     if (
@@ -57,7 +72,7 @@ export function createGatsbyImages(element) {
       element[subElement] === "image" &&
       element.asset
     ) {
-      element.asset.gatsbyImageData = imageCreator(element.asset);
+      element.asset.gatsbyImageData = imageCreator(element.asset, isGroqResult);
       return;
     }
   });

--- a/packages/website/src/server-side/sanityClient.js
+++ b/packages/website/src/server-side/sanityClient.js
@@ -1,0 +1,10 @@
+import configuration from "../config";
+import { createClient } from "@sanity/client";
+
+export const sanityClient = createClient({
+  projectId: configuration.SANITY_PROJECT_ID,
+  dataset: configuration.SANITY_DATASET,
+  token: configuration.SANITY_TOKEN,
+  useCdn: false, // set to `false` to bypass the edge cache
+  apiVersion: "2023-05-03", // use current date (YYYY-MM-DD) to target the latest API version
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9466,6 +9466,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sanity/client@npm:^6.1.3":
+  version: 6.1.3
+  resolution: "@sanity/client@npm:6.1.3"
+  dependencies:
+    "@sanity/eventsource": ^5.0.0
+    get-it: ^8.1.0
+    rxjs: ^7.0.0
+  checksum: fbc60d16bbe5a802c978a28dc5f33566323f137ec2f304e71b65c29e2ca9013c88c4e3d2778f19891c7d47fd69f8812682759575510fa19c077bbbab4342ed83
+  languageName: node
+  linkType: hard
+
 "@sanity/color@npm:^2.1.5":
   version: 2.1.5
   resolution: "@sanity/color@npm:2.1.5"
@@ -9676,6 +9687,18 @@ __metadata:
     "@rexxars/eventsource-polyfill": ^1.0.0
     eventsource: ^1.0.6
   checksum: 1f8afab37bf70451b5e3f68972efd9d239211cce81b345a505dbc02f4c54b4df4e4b606c939727a2043ca366d05a7086de2fac4251dc1040e411c96fa7babcf9
+  languageName: node
+  linkType: hard
+
+"@sanity/eventsource@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "@sanity/eventsource@npm:5.0.0"
+  dependencies:
+    "@types/event-source-polyfill": 1.0.1
+    "@types/eventsource": 1.1.11
+    event-source-polyfill: 1.0.31
+    eventsource: 2.0.2
+  checksum: 172cf4208e20acd5bb159f7dacfee4e6e252a50f19aa5647b348d33856c3021f1ed2167dd45d385e18ce1b56f181ba11e717d51945140f6c369a6683890a2dd2
   languageName: node
   linkType: hard
 
@@ -11839,10 +11862,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/event-source-polyfill@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@types/event-source-polyfill@npm:1.0.1"
+  checksum: 37f3ccc40e2fc43230047c3323f8bfc55f6ed40aee8c61af7f6b702a923be5615362cf3241f5a536f9c64932309a2184a0181bb48e105a94b968b8321cae1c60
+  languageName: node
+  linkType: hard
+
 "@types/events@npm:*":
   version: 3.0.0
   resolution: "@types/events@npm:3.0.0"
   checksum: 9a424c2da210957d5636e0763e8c9fc3aaeee35bf411284ddec62a56a6abe31de9c7c2e713dabdd8a76ff98b47db2bd52f61310be6609641d6234cc842ecbbe3
+  languageName: node
+  linkType: hard
+
+"@types/eventsource@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@types/eventsource@npm:1.1.11"
+  checksum: 84cd8595b43f8d0cdb857102e78ae35e9ff7284daa72085b114caaf90de14bca96b1c604553b9055eda19a76e2b161fb764e8cd4aba1824f81feec98fa331c1c
   languageName: node
   linkType: hard
 
@@ -18714,6 +18751,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"decompress-response@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "decompress-response@npm:7.0.0"
+  dependencies:
+    mimic-response: ^3.1.0
+  checksum: dfd216a4b24c6a9840e19986e8a9ca62e0b6ae35458e4135fdb84f2ba531a03ddc6ccfdc72782a361583c7d12a59787503381bd8372bf83f849eafadbaa8629c
+  languageName: node
+  linkType: hard
+
 "dedent@npm:^0.7.0":
   version: 0.7.0
   resolution: "dedent@npm:0.7.0"
@@ -21217,6 +21263,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"event-source-polyfill@npm:1.0.31":
+  version: 1.0.31
+  resolution: "event-source-polyfill@npm:1.0.31"
+  checksum: 973f226404e2a1b14ed7ef15c718b89e213b41d7cfeeb1c10937fd09229f13904f3d7c3075ab28ccf858c213007559908eecdd577577330352f53a351383dd75
+  languageName: node
+  linkType: hard
+
 "event-source-polyfill@npm:^1.0.25":
   version: 1.0.25
   resolution: "event-source-polyfill@npm:1.0.25"
@@ -21263,6 +21316,13 @@ __metadata:
   version: 0.9.6
   resolution: "eventsource-polyfill@npm:0.9.6"
   checksum: f0844cfd36a4c48661794cb7b2b494db2c4ad7b7721c232b54e1e297396770569bd0ebf34aad8181d1184ae453bc11facfc98277f92876c17e6cae6e7b180e41
+  languageName: node
+  linkType: hard
+
+"eventsource@npm:2.0.2":
+  version: 2.0.2
+  resolution: "eventsource@npm:2.0.2"
+  checksum: c0072d972753e10c705d9b2285b559184bf29d011bc208973dde9c8b6b8b7b6fdad4ef0846cecb249f7b1585e860fdf324cbd2ac854a76bc53649e797496e99a
   languageName: node
   linkType: hard
 
@@ -22239,6 +22299,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"follow-redirects@npm:^1.15.2":
+  version: 1.15.2
+  resolution: "follow-redirects@npm:1.15.2"
+  peerDependenciesMeta:
+    debug:
+      optional: true
+  checksum: faa66059b66358ba65c234c2f2a37fcec029dc22775f35d9ad6abac56003268baf41e55f9ee645957b32c7d9f62baf1f0b906e68267276f54ec4b4c597c2b190
+  languageName: node
+  linkType: hard
+
 "for-each@npm:^0.3.3":
   version: 0.3.3
   resolution: "for-each@npm:0.3.3"
@@ -22449,7 +22519,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"from2@npm:^2.1.0, from2@npm:^2.1.1":
+"from2@npm:^2.1.0, from2@npm:^2.1.1, from2@npm:^2.3.0":
   version: 2.3.0
   resolution: "from2@npm:2.3.0"
   dependencies:
@@ -23726,6 +23796,24 @@ fsevents@^1.2.7:
     tunnel-agent: ^0.6.0
     url-parse: ^1.1.9
   checksum: 6cc07f27ceb6ccefc63cdefd90534a65d83023e6ac91ed78425b984f9ded8a7e476a4401709b90709276ff66a95d4fb918cb7bd267f64518eb6ef706f856fc74
+  languageName: node
+  linkType: hard
+
+"get-it@npm:^8.1.0":
+  version: 8.1.3
+  resolution: "get-it@npm:8.1.3"
+  dependencies:
+    debug: ^4.3.4
+    decompress-response: ^7.0.0
+    follow-redirects: ^1.15.2
+    into-stream: ^6.0.0
+    is-plain-object: ^5.0.0
+    is-retry-allowed: ^2.2.0
+    is-stream: ^2.0.1
+    parse-headers: ^2.0.5
+    progress-stream: ^2.0.0
+    tunnel-agent: ^0.6.0
+  checksum: c2bd056f6e6ecda78bf14c64c1f36f3a8eef6dbb53430a4de90e57e9e7fe4deba40428adb2af0cb63012790bcb52ec1a2974f8d888d9e509d8f3ec0ce8e16f17
   languageName: node
   linkType: hard
 
@@ -25790,6 +25878,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"into-stream@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "into-stream@npm:6.0.0"
+  dependencies:
+    from2: ^2.3.0
+    p-is-promise: ^3.0.0
+  checksum: 8df24c9eadd7cdd1cbc160bc20914b961dfd0ca29767785b69e698f799e85466b6f7c637d237dca1472d09d333399f70cc05a2fb8d08cb449dc9a80d92193980
+  languageName: node
+  linkType: hard
+
 "invariant@npm:^2.2.3, invariant@npm:^2.2.4":
   version: 2.2.4
   resolution: "invariant@npm:2.2.4"
@@ -26521,6 +26619,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-plain-object@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "is-plain-object@npm:5.0.0"
+  checksum: e32d27061eef62c0847d303125440a38660517e586f2f3db7c9d179ae5b6674ab0f469d519b2e25c147a1a3bc87156d0d5f4d8821e0ce4a9ee7fe1fcf11ce45c
+  languageName: node
+  linkType: hard
+
 "is-potential-custom-element-name@npm:^1.0.0":
   version: 1.0.0
   resolution: "is-potential-custom-element-name@npm:1.0.0"
@@ -26617,6 +26722,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"is-retry-allowed@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "is-retry-allowed@npm:2.2.0"
+  checksum: 3d1103a9290b5d03626756a41054844633eac78bc5d3e3a95b13afeae94fa3cfbcf7f0b5520d83f75f48a25ce7b142fdbac4217dc4b0630f3ea55e866ec3a029
+  languageName: node
+  linkType: hard
+
 "is-root@npm:2.1.0":
   version: 2.1.0
   resolution: "is-root@npm:2.1.0"
@@ -26674,6 +26786,13 @@ fsevents@^1.2.7:
   version: 2.0.0
   resolution: "is-stream@npm:2.0.0"
   checksum: 4dc47738e26bc4f1b3be9070b6b9e39631144f204fc6f87db56961220add87c10a999ba26cf81699f9ef9610426f69cb08a4713feff8deb7d8cadac907826935
+  languageName: node
+  linkType: hard
+
+"is-stream@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "is-stream@npm:2.0.1"
+  checksum: b8e05ccdf96ac330ea83c12450304d4a591f9958c11fd17bed240af8d5ffe08aedafa4c0f4cfccd4d28dc9d4d129daca1023633d5c11601a6cbc77521f6fae66
   languageName: node
   linkType: hard
 
@@ -32096,6 +32215,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"p-is-promise@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "p-is-promise@npm:3.0.0"
+  checksum: 74e511225fde5eeda7a120d51c60c284de90d68dec7c73611e7e59e8d1c44cc7e2246686544515849149b74ed0571ad470a456ac0d00314f8d03d2cc1ad43aae
+  languageName: node
+  linkType: hard
+
 "p-limit@npm:3.1.0, p-limit@npm:^3.1.0":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
@@ -32378,6 +32504,13 @@ fsevents@^1.2.7:
   version: 2.0.3
   resolution: "parse-headers@npm:2.0.3"
   checksum: 32658e1c923cde921fbb170ad3ef9700bfd56bcb6b649df03380b1d8ef60ab05d9f066dcfa7b13c732f2a1ce272f1e637dfd453345fb3041e86a2a9250326096
+  languageName: node
+  linkType: hard
+
+"parse-headers@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "parse-headers@npm:2.0.5"
+  checksum: 3e97f01e4c7f960bfbfd0ee489f0bd8d3c72b6c814f1f79b66abec2cca8eaf8e4ecd89deba0b6e61266469aed87350bc932001181c01ff8c29a59e696abe251f
   languageName: node
   linkType: hard
 
@@ -37377,6 +37510,15 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"rxjs@npm:^7.0.0":
+  version: 7.8.1
+  resolution: "rxjs@npm:7.8.1"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: de4b53db1063e618ec2eca0f7965d9137cabe98cf6be9272efe6c86b47c17b987383df8574861bcced18ebd590764125a901d5506082be84a8b8e364bf05f119
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:*, safe-buffer@npm:5.2.1, safe-buffer@npm:^5.0.1, safe-buffer@npm:^5.1.0, safe-buffer@npm:^5.1.1, safe-buffer@npm:^5.1.2, safe-buffer@npm:^5.2.0, safe-buffer@npm:~5.2.0":
   version: 5.2.1
   resolution: "safe-buffer@npm:5.2.1"
@@ -42268,6 +42410,7 @@ typescript@^4.0.5:
     "@babel/core": ^7.12.10
     "@mdx-js/react": ^1.6.22
     "@sanity/block-content-to-react": ^2.0.7
+    "@sanity/client": ^6.1.3
     "@sanity/image-url": ^0.140.22
     "@storybook/addon-actions": ^6.3.0-alpha.12
     "@storybook/addon-controls": ^6.3.0-alpha.12


### PR DESCRIPTION
We now show a 500 page whenever someone hits an unpublished page
- Transitioned `jobbe-i-alv`-pages to use GROQ instead of graphql due to limitations from the sanity API. Benefit is that the API is much easier to use and queries are very easy to read
- Added a 500 page
- Modified gatsbyImage-integration to work with image-data retrieved by GROQ queries
- Added jsdoc-typings to configuration
- Added a simple sanityClient to make it easier to use in the future