### PR TITLE
965: split name into firstname and lastname, fix error handling

### DIFF
--- a/packages/shared-components/src/components/richTextTypes/cta/formCta/index.js
+++ b/packages/shared-components/src/components/richTextTypes/cta/formCta/index.js
@@ -23,7 +23,8 @@ const Form = ({ identifier }) => {
   const [status, setStatus] = useState("validating");
   const [inputValues, handleInputChange] = useForm({
     subject: `Form-Cta - ${identifier}`,
-    name: "",
+    firstname: "",
+    lastname: "",
     email: "",
     body: "",
   });
@@ -47,18 +48,29 @@ const Form = ({ identifier }) => {
     <FormFeedbackWrapper status={status}>
       <form className={styles.form} onSubmit={handleSubmitClick}>
         <div className="">
-          <FormLabel>Navn</FormLabel>
+          <FormLabel>Fornavn *</FormLabel>
           <input
             className={styles.input}
-            value={inputValues.name}
+            value={inputValues.firstname}
             onChange={handleInputChange}
-            name="name"
+            name="firstname"
             type="text"
             required
           />
         </div>
-        <div>
-          <FormLabel>E-post</FormLabel>
+        <div className="">
+          <FormLabel>Etternavn *</FormLabel>
+          <input
+            className={styles.input}
+            value={inputValues.lastname}
+            onChange={handleInputChange}
+            name="lastname"
+            type="text"
+            required
+          />
+        </div>
+        <div className={styles.textareaWrapper}>
+          <FormLabel>E-post *</FormLabel>
           <input
             className={styles.input}
             value={inputValues.email}

--- a/packages/shared-components/src/utils.js
+++ b/packages/shared-components/src/utils.js
@@ -62,8 +62,9 @@ export const submitWithDelay = async (apiUrl, body) => {
     .then((response) => {
       if (!response.ok) {
         submissionResponseStatus = "error";
+      } else {
+        submissionResponseStatus = "success";
       }
-      submissionResponseStatus = "success";
     })
     .catch(() => {
       submissionResponseStatus = "error";


### PR DESCRIPTION
Løser https://github.com/Alv-no/alv-website/issues/965

- Deler "name"-inputfelt i "firstname" og "lastname" frontend fordi det er dette endepunktet forventer
- Viser feilmelding når serveren returnerer noe annet enn 200.